### PR TITLE
Add slider for global HD text scaling

### DIFF
--- a/d2gl/src/app.h
+++ b/d2gl/src/app.h
@@ -129,11 +129,10 @@ struct D2GLApp {
 
 	struct {
 		bool active = false;
-		Range<float> scale = { 1.0f, 0.1f, 2.0f };
+		Range<float> scale = { 1.0f, 0.5f, 1.2f };
 	} hd_text;
 
 	bool hd_cursor = false;
-	// bool hd_text = false;
 	bool motion_prediction = false;
 	bool skip_intro = false;
 	bool no_pickup = false;

--- a/d2gl/src/app.h
+++ b/d2gl/src/app.h
@@ -127,8 +127,13 @@ struct D2GLApp {
 		Range<float> gamma = { 1.0f, 0.5f, 1.2f };
 	} bloom;
 
+	struct {
+		bool active = false;
+		Range<float> scale = { 1.0f, 0.1f, 2.0f };
+	} hd_text;
+
 	bool hd_cursor = false;
-	bool hd_text = false;
+	// bool hd_text = false;
 	bool motion_prediction = false;
 	bool skip_intro = false;
 	bool no_pickup = false;

--- a/d2gl/src/d2/funcs.cpp
+++ b/d2gl/src/d2/funcs.cpp
@@ -329,7 +329,7 @@ void __fastcall takeScreenShotHooked()
 void __fastcall drawNormalTextHooked(const wchar_t* str, int x, int y, uint32_t color, uint32_t centered)
 {
 	// Glide mode light gray text appears black. So direct to dark gray.
-	if (ISGLIDE3X() && !App.hd_text && color == 15)
+	if (ISGLIDE3X() && !App.hd_text.active && color == 15)
 		color = 5;
 
 	const auto pos = modules::MotionPrediction::Instance().drawText(str, x, y, D2DrawFn::NormalText);

--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -87,8 +87,9 @@ HDText::HDText()
 			wchar_t color = g_initial_colors.find(id) != g_initial_colors.end() ? g_initial_colors.at(id) : 0;
 			const auto offset = glm::vec2(std::stof(info[7]), std::stof(info[8]));
 			float font_size = std::stof(info[2]) * App.hd_text.scale.value;
+			float line_height = std::stof(info[5]) * App.hd_text.scale.value;
 
-			FontCreateInfo font_ci = { name, font_size, std::stof(info[3]), std::stof(info[4]), std::stof(info[5]), std::stof(info[6]), offset, std::stof(info[9]), color, bordered };
+			FontCreateInfo font_ci = { name, font_size, std::stof(info[3]), std::stof(info[4]), line_height, std::stof(info[6]), offset, std::stof(info[9]), color, bordered };
 			m_fonts[id] = std::make_unique<Font>(glyph_sets[name], font_ci);
 		}
 

--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -86,8 +86,9 @@ HDText::HDText()
 			bool bordered = (id == 2 || id == 3 || id == 7 || id == 18);
 			wchar_t color = g_initial_colors.find(id) != g_initial_colors.end() ? g_initial_colors.at(id) : 0;
 			const auto offset = glm::vec2(std::stof(info[7]), std::stof(info[8]));
+			float font_size = std::stof(info[2]) * App.hd_text.scale.value;
 
-			FontCreateInfo font_ci = { name, std::stof(info[2]), std::stof(info[3]), std::stof(info[4]), std::stof(info[5]), std::stof(info[6]), offset, std::stof(info[9]), color, bordered };
+			FontCreateInfo font_ci = { name, font_size, std::stof(info[3]), std::stof(info[4]), std::stof(info[5]), std::stof(info[6]), offset, std::stof(info[9]), color, bordered };
 			m_fonts[id] = std::make_unique<Font>(glyph_sets[name], font_ci);
 		}
 
@@ -948,7 +949,7 @@ void HDText::drawItemQuantity(int x, int y)
 
 			const auto old_size = modules::HDText::Instance().getTextSize();
 			d2::setTextSizeHooked(6);
-			if (App.hd_text) {
+			if (App.hd_text.active) {
 				static auto bg = std::make_unique<Object>();
 				uint32_t width, height;
 

--- a/d2gl/src/modules/hd_text.h
+++ b/d2gl/src/modules/hd_text.h
@@ -77,7 +77,7 @@ public:
 		return instance;
 	}
 
-	inline bool isActive() { return App.hd_text; }
+	inline bool isActive() { return App.hd_text.active; }
 	inline void setMVP(const glm::mat4& mvp) { m_mvp = mvp; }
 
 	void reset();

--- a/d2gl/src/modules/hd_text/font.h
+++ b/d2gl/src/modules/hd_text/font.h
@@ -74,7 +74,7 @@ public:
 	inline wchar_t getColor() { return m_color; }
 	inline float getFontSize() { return m_size; }
 	inline float getWeight() { return m_weight; }
-	inline float getLineHeight() { return m_size * m_line_height; }
+	inline float getLineHeight() { return m_size * m_line_height * App.hd_text.scale.value; }
 	inline float getLetterSpacing() { return m_size * m_letter_spacing; }
 	inline glm::vec2 getTextOffset() { return m_size * m_offset; }
 	inline int getLineCount() { return m_line_count; }

--- a/d2gl/src/modules/hd_text/font.h
+++ b/d2gl/src/modules/hd_text/font.h
@@ -66,7 +66,7 @@ public:
 	Font(GlyphSet* glyph_set, const FontCreateInfo& font_ci);
 	~Font() = default;
 
-	inline void setSize(float size) { m_size = size, m_scale = size / 32.0f, m_smoothness = size; }
+	inline void setSize(float size) { m_size = size / App.hd_text.scale.value, m_scale = size / 32.0f, m_smoothness = size; }
 	inline void setAlign(TextAlign align) { m_align = align; }
 	inline void setShadow(uint8_t level = 0) { m_shadow_level = level; }
 	inline void setMasking(bool masking) { m_masking = masking; }

--- a/d2gl/src/modules/mini_map.cpp
+++ b/d2gl/src/modules/mini_map.cpp
@@ -65,7 +65,7 @@ void MiniMap::draw()
 			App.context->pushObject(m_map);
 		}
 
-		if (App.hd_text) {
+		if (App.hd_text.active) {
 			time_t now = time(0);
 			localtime_s(&gmt_time, &now);
 			swprintf_s(time_str, L" | ÿc\x34%.2d:%.2d", gmt_time.tm_hour, gmt_time.tm_min);

--- a/d2gl/src/option/ini.cpp
+++ b/d2gl/src/option/ini.cpp
@@ -225,6 +225,7 @@ void saveIni()
 		"hd_cursor=%s\n\n"
 		"; HD in game text.\n"
 		"hd_text=%s\n\n"
+		"hd_text_scale=%.2f\n\n"
 		//"; HD life & mana orbs.\n"
 		//"hd_orbs=%s\n"
 		//"hd_orbs_centered=%s\n\n"
@@ -248,7 +249,8 @@ void saveIni()
 
 	sprintf_s(buf, feature_setting,
 		boolString(App.hd_cursor),
-		boolString(App.hd_text),
+		boolString(App.hd_text.active),
+		App.hd_text.scale.value,
 		// boolString(App.hd_orbs.active),
 		// boolString(App.hd_orbs.centered),
 		boolString(App.mini_map.active),
@@ -346,7 +348,8 @@ void loadIni()
 		App.viewport.stretched.y = getBool("Graphic", "stretched_vertical", App.viewport.stretched.y);
 
 		App.hd_cursor = getBool("Feature", "hd_cursor", App.hd_cursor);
-		App.hd_text = getBool("Feature", "hd_text", App.hd_text);
+		App.hd_text.active = getBool("Feature", "hd_text", App.hd_text.active);
+		App.hd_text.scale.value = getFloat("Feature", "hd_text_scale", App.hd_text.scale);
 
 		// App.hd_orbs.active = getBool("Feature", "hd_orbs", App.hd_orbs.active);
 		// App.hd_orbs.centered = getBool("Feature", "hd_orbs_centered", App.hd_orbs.centered);

--- a/d2gl/src/option/menu.cpp
+++ b/d2gl/src/option/menu.cpp
@@ -310,11 +310,20 @@ void Menu::draw()
 			drawCheckbox_m("HD Cursor", App.hd_cursor, "High-definition in game & menu screen cursor.", hd_cursor)
 				saveBool("Feature", "hd_cursor", App.hd_cursor);
 			drawSeparator();
-			drawCheckbox_m("HD Text", App.hd_text, "High-definition ingame texts.", hd_text)
+			drawCheckbox_m("HD Text", App.hd_text.active, "High-definition ingame texts.", hd_text)
 			{
-				d2::patch_hd_text->toggle(App.hd_text);
-				saveBool("Feature", "hd_text", App.hd_text);
+				d2::patch_hd_text->toggle(App.hd_text.active);
+				saveBool("Feature", "hd_text", App.hd_text.active);
 			}
+			drawSlider_m(float, "", App.hd_text.scale, "%.2f", "", hd_text_scale)
+			{
+				for (int i = 0; i < 23; i++) {
+					  const auto font = modules::HDText::Instance().getFont((uint32_t)i);
+					  font->setSize(font->getFontSize() * App.hd_text.scale.value);
+				}
+				saveFloat("Feature", "hd_text_scale", App.hd_text.scale.value);
+			}
+			drawDescription("Scale for HD text size", m_colors[Color::Gray], 12);
 			drawSeparator();
 			ImGui::BeginDisabled(!ISGLIDE3X() || !App.mini_map.available);
 				drawCheckbox_m("Mini Map", App.mini_map.active, "Always on minimap widget.", mini_map)
@@ -341,9 +350,6 @@ void Menu::draw()
 					}
 				ImGui::EndDisabled();
 			ImGui::EndDisabled();
-			drawSeparator();
-			drawCheckbox_m("Show Item Quantity", App.show_item_quantity, "Show item quantity on bottom left corner of icon.", show_item_quantity)
-				saveBool("Feature", "show_item_quantity", App.show_item_quantity);
 			/*drawSeparator();
 			ImGui::BeginDisabled(true);
 				drawCheckbox_m("HD Orbs", App.hd_orbs.active, "High-definition life & mana orbs. (coming soon)", hd_orbs)
@@ -374,6 +380,9 @@ void Menu::draw()
 			drawSeparator();
 			drawCheckbox_m("Unlock Cursor", App.cursor.unlock, "Cursor will not locked within window.", unlock_cursor)
 				saveBool("Feature", "unlock_cursor", App.cursor.unlock);
+			drawSeparator();
+			drawCheckbox_m("Show Item Quantity", App.show_item_quantity, "Show item quantity on bottom left corner of icon.", show_item_quantity)
+				saveBool("Feature", "show_item_quantity", App.show_item_quantity);
 			childEnd();
 			tabEnd();
 		}


### PR DESCRIPTION
While I love the font customization that was added, it does seem a little tedious to adjust.
Font sizing seems like it would be the most commonly adjusted element by far (at least in my opinion), so I figured it would be worth streamlining that adjustment. By no means is this meant to replace the builds used for in-depth font tuning.

The scaling range admittedly seems a little wide, but I wanted to leave room for some of the naturally large or small fonts to be sized appropriately (as a bad example, something like Papyrus).