### PR TITLE
fix "FPS" font size without HD Text

### DIFF
--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -961,7 +961,7 @@ void HDText::drawFpsCounter()
 	swprintf_s(str, L"FPS: %.0f", fps);
 
 	const auto old_size = HDText::Instance().getTextSize();
-	d2::setTextSizeHooked(19);
+	App.hd_text.active ? d2::setTextSizeHooked(19) : d2::setTextSizeHooked(6);  // fix "FPS" text size in game when close the HD Text. 
 	const auto width = d2::getNormalTextWidthHooked(str);
 	d2::drawNormalTextHooked(str, App.game.size.x / 2 - width / 2, App.game.size.y - 58, 4, 0);
 	d2::setTextSizeHooked(old_size);


### PR DESCRIPTION
fix "FPS" text size in game when close the HD Text.

because when close the HD text the "FPS" will too big and ugly.
HDTextOn:
![HDTextOn](https://github.com/bayaraa/d2gl/assets/2888483/022ad311-305d-485a-aabc-87d01fba1301)
HDTextOff:
![HDTextOff](https://github.com/bayaraa/d2gl/assets/2888483/3d1cf6f1-e08c-472c-bc46-44683ec996b6)
HDTextOffFix:
![HDTextOffFix](https://github.com/bayaraa/d2gl/assets/2888483/4be6134e-9ebc-47d7-a354-e05fcf7d9cb2)
