### PR TITLE
add borderless window mode

### DIFF
--- a/d2gl/src/app.h
+++ b/d2gl/src/app.h
@@ -68,6 +68,7 @@ struct D2GLApp {
 		glm::uvec2 size = { 800, 600 };
 		glm::uvec2 size_save = { 800, 600 };
 		bool fullscreen = false;
+		bool borderless = false;
 		bool auto_minimize = false;
 		bool centered = true;
 		bool dark_mode = true;

--- a/d2gl/src/option/ini.cpp
+++ b/d2gl/src/option/ini.cpp
@@ -130,6 +130,9 @@ void saveIni()
 		"; Game will run in fullscreen window.\n"
 		"; Window size (window_width/window_height) will be ignored.\n"
 		"fullscreen=%s\n\n"
+		"; Borderless window (no title bar, borders or caption buttons).\n"
+		"; Ignored while fullscreen is enabled.\n"
+		"borderless_window=%s\n\n"
 		"; Window size.\n"
 		"window_width=%d\n"
 		"window_height=%d\n\n"
@@ -159,6 +162,7 @@ void saveIni()
 
 	sprintf_s(buf, screen_setting,
 		boolString(App.window.fullscreen),
+		boolString(App.window.borderless),
 		App.window.size.x,
 		App.window.size.y,
 		boolString(App.window.centered),
@@ -307,6 +311,7 @@ void loadIni()
 
 	if (helpers::fileExists(App.ini_file)) {
 		App.window.fullscreen = getBool("Screen", "fullscreen", App.window.fullscreen);
+		App.window.borderless = getBool("Screen", "borderless_window", App.window.borderless);
 		App.window.auto_minimize = getBool("Screen", "auto_minimize", App.window.auto_minimize);
 		App.window.dark_mode = getBool("Screen", "dark_mode", App.window.dark_mode);
 		App.vsync = getBool("Screen", "vsync", App.vsync);

--- a/d2gl/src/option/menu.cpp
+++ b/d2gl/src/option/menu.cpp
@@ -46,6 +46,8 @@ namespace d2gl::option {
 
 Menu::Menu()
 {
+	m_window_mode.items = { { "Windowed", WINDOW_MODE_WINDOWED }, { "Borderless", WINDOW_MODE_BORDERLESS }, { "Fullscreen", WINDOW_MODE_FULLSCREEN } };
+
 	m_colors[Color::Default] = ImColor(199, 179, 119);
 	m_colors[Color::Orange] = ImColor(255, 150, 0);
 	m_colors[Color::White] = ImColor(255, 255, 255, 180);
@@ -122,6 +124,7 @@ void Menu::toggle(bool force)
 	if (m_visible) {
 		m_options.vsync = App.vsync;
 		m_options.window = App.window;
+		m_window_mode.selected = App.window.fullscreen ? WINDOW_MODE_FULLSCREEN : (App.window.borderless ? WINDOW_MODE_BORDERLESS : WINDOW_MODE_WINDOWED);
 		m_options.foreground_fps = App.foreground_fps;
 		m_options.background_fps = App.background_fps;
 		m_options.unlock_cursor = App.cursor.unlock;
@@ -190,13 +193,12 @@ void Menu::draw()
 		if (tabBegin("Screen", 0, &active_tab)) {
 			bool changed = m_options.pos_changed;
 			childBegin("##w1", true, true);
-			drawCheckbox_m("Fullscreen", m_options.window.fullscreen, "Game will run in windowed mode if unchecked.", fullscreen);
-			checkChanged(m_options.window.fullscreen != App.window.fullscreen);
+			drawCombo_m("Window Mode", m_window_mode, "", false, 17, window_mode);
+			m_options.window.fullscreen = m_window_mode.selected == WINDOW_MODE_FULLSCREEN;
+			m_options.window.borderless = m_window_mode.selected == WINDOW_MODE_BORDERLESS;
+			checkChanged(m_options.window.fullscreen != App.window.fullscreen || m_options.window.borderless != App.window.borderless);
 			drawSeparator();
 			ImGui::BeginDisabled(m_options.window.fullscreen);
-				drawCheckbox_m("Borderless Window", m_options.window.borderless, "Window without title bar & borders.", borderless_window);
-				checkChanged(m_options.window.borderless != App.window.borderless);
-				drawSeparator();
 				drawCombo_m("Window Size", App.resolutions, "", false, 17, resolutions);
 				checkChanged(App.resolutions.items[App.resolutions.selected].value != m_options.window.size_save);
 				ImGui::Dummy({ 0.0f, 1.0f });
@@ -241,8 +243,10 @@ void Menu::draw()
 			drawCheckbox_m("Auto Minimize", m_options.window.auto_minimize, "Auto minimize when lose focus while in fullscreen.", auto_minimize);
 			checkChanged(m_options.window.auto_minimize != App.window.auto_minimize);
 			drawSeparator();
-			drawCheckbox_m("Dark Mode", m_options.window.dark_mode, "Dark window title bar. Affect on next launch.", dark_mode);
-			checkChanged(m_options.window.dark_mode != App.window.dark_mode);
+			ImGui::BeginDisabled(m_options.window.fullscreen || m_options.window.borderless);
+				drawCheckbox_m("Dark Mode", m_options.window.dark_mode, "Dark window title bar. Affect on next launch.", dark_mode);
+				checkChanged(m_options.window.dark_mode != App.window.dark_mode);
+			ImGui::EndDisabled();
 			childEnd();
 			ImGui::BeginDisabled(!changed);
 				if (drawNav("Apply Changes")) {

--- a/d2gl/src/option/menu.cpp
+++ b/d2gl/src/option/menu.cpp
@@ -194,6 +194,9 @@ void Menu::draw()
 			checkChanged(m_options.window.fullscreen != App.window.fullscreen);
 			drawSeparator();
 			ImGui::BeginDisabled(m_options.window.fullscreen);
+				drawCheckbox_m("Borderless Window", m_options.window.borderless, "Window without title bar & borders.", borderless_window);
+				checkChanged(m_options.window.borderless != App.window.borderless);
+				drawSeparator();
 				drawCombo_m("Window Size", App.resolutions, "", false, 17, resolutions);
 				checkChanged(App.resolutions.items[App.resolutions.selected].value != m_options.window.size_save);
 				ImGui::Dummy({ 0.0f, 1.0f });
@@ -252,6 +255,7 @@ void Menu::draw()
 						window_pos_cond = ImGuiCond_Always;
 
 					App.window.fullscreen = m_options.window.fullscreen;
+					App.window.borderless = m_options.window.borderless;
 					App.window.size = m_options.window.size_save;
 					App.window.size_save = m_options.window.size_save;
 					App.window.centered = m_options.window.centered;
@@ -264,6 +268,7 @@ void Menu::draw()
 					App.background_fps = m_options.background_fps;
 
 					saveBool("Screen", "fullscreen", App.window.fullscreen);
+					saveBool("Screen", "borderless_window", App.window.borderless);
 					saveInt("Screen", "window_width", App.window.size.x);
 					saveInt("Screen", "window_height", App.window.size.y);
 					saveBool("Screen", "centered_window", App.window.centered);

--- a/d2gl/src/option/menu.h
+++ b/d2gl/src/option/menu.h
@@ -29,6 +29,14 @@ enum class Color {
 	Gray,
 };
 
+// Borderless is a windowed mode, so it keeps its own [Screen] key rather than folding into
+// fullscreen. The three are mutually exclusive only as far as the menu is concerned.
+enum WindowMode {
+	WINDOW_MODE_WINDOWED,
+	WINDOW_MODE_BORDERLESS,
+	WINDOW_MODE_FULLSCREEN,
+};
+
 struct Options {
 	bool vsync = false;
 	bool unlock_cursor = false;
@@ -46,6 +54,7 @@ class Menu {
 	std::unordered_map<int, ImFont*> m_fonts;
 	std::unordered_map<Color, ImVec4> m_colors;
 	Options m_options;
+	Select<int> m_window_mode;
 	bool m_ignore_font = false;
 
 	Menu();

--- a/d2gl/src/win32.cpp
+++ b/d2gl/src/win32.cpp
@@ -348,6 +348,14 @@ void setWindow(HWND hwnd)
 	App.window.style |= WS_OVERLAPPEDWINDOW & ~(WS_SIZEBOX | WS_MAXIMIZEBOX);
 }
 
+DWORD getWindowStyle()
+{
+	if (App.window.borderless)
+		return (App.window.style & ~WS_OVERLAPPEDWINDOW) | WS_POPUP;
+
+	return App.window.style;
+}
+
 void setWindowRect()
 {
 	HMONITOR monitor = MonitorFromWindow(App.hwnd, MONITOR_DEFAULTTONEAREST);
@@ -372,19 +380,20 @@ void setWindowRect()
 		y = (y > wr.top + screen_h - 50) ? wr.top + screen_h - 50 : y;
 		wr = { x, y, (LONG)App.window.size.x + x, (LONG)App.window.size.y + y };
 
-		SetWindowLong(App.hwnd, GWL_STYLE, App.window.style);
+		const DWORD style = getWindowStyle();
+		SetWindowLong(App.hwnd, GWL_STYLE, style);
 
 		RECT wr_test = { 0 };
-		AdjustWindowRect(&wr_test, App.window.style, FALSE);
+		AdjustWindowRect(&wr_test, style, FALSE);
 
 		wr.left -= wr_test.left;
 		wr.right -= wr_test.left;
 		wr.top -= wr_test.top;
 		wr.bottom -= wr_test.top;
 
-		AdjustWindowRect(&wr, App.window.style, FALSE);
-		SetWindowPos_Og(App.hwnd, HWND_NOTOPMOST, wr.left, wr.top, (wr.right - wr.left), (wr.bottom - wr.top), SWP_SHOWWINDOW);
-		trace_log("Switched to windowed mode: %d x %d", App.window.size.x, App.window.size.y);
+		AdjustWindowRect(&wr, style, FALSE);
+		SetWindowPos_Og(App.hwnd, HWND_NOTOPMOST, wr.left, wr.top, (wr.right - wr.left), (wr.bottom - wr.top), SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+		trace_log("Switched to %s windowed mode: %d x %d", (App.window.borderless ? "borderless" : "bordered"), App.window.size.x, App.window.size.y);
 	} else {
 		SetWindowLong(App.hwnd, GWL_STYLE, App.window.style & ~WS_OVERLAPPEDWINDOW);
 		App.window.size = { screen_w, screen_h };

--- a/d2gl/src/win32.h
+++ b/d2gl/src/win32.h
@@ -62,6 +62,7 @@ COLORREF WINAPI GetPixel(HDC hdc, int x, int y);
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 void setWindow(HWND hwnd);
+DWORD getWindowStyle();
 void setWindowRect();
 void setWindowMetrics();
 void setCursorLock();


### PR DESCRIPTION
Adds a borderless windowed mode: no title bar, no borders, no caption buttons, by swapping `WS_OVERLAPPEDWINDOW` for `WS_POPUP`.

## Settings

A new `[Screen]` key, `borderless_window`. Windowed and fullscreen keep their existing keys and meanings, so an existing `d2gl.ini` is unaffected.

In the menu, the Screen tab's `Fullscreen` checkbox becomes a `Window Mode` combo with Windowed / Borderless / Fullscreen. They are one mutually exclusive choice, and a second checkbox would have meant `Borderless` sitting disabled whenever `Fullscreen` was ticked. It also keeps the tab's row count flat: that column is a fixed-height child frame, and an extra row pushes it into scrolling.

`Dark Mode` now greys out unless the mode is Windowed, since a hidden title bar has no colour to set.

## Testing

Built `x86|Release` (`glide3x.dll` and `ddraw.dll`), and exercised in game: switching between all three modes from the menu, with window size, centering and position behaving in borderless as they do windowed, and the setting persisting across a restart.